### PR TITLE
Update to .NET 6

### DIFF
--- a/Properties/PublishProfiles/Portable.pubxml
+++ b/Properties/PublishProfiles/Portable.pubxml
@@ -8,7 +8,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <Platform>Any CPU</Platform>
     <PublishDir>bin\Publish\portable</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <SelfContained>true</SelfContained>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishSingleFile>True</PublishSingleFile>

--- a/README.html
+++ b/README.html
@@ -10,8 +10,8 @@
 <h2 id="section">動作環境</h2>
 <p>Windows 10(32/64bit), 11(32/64bit)</p>
 <h2 id="section-1">追加のライブラリ</h2>
-<p><a href="https://dotnet.microsoft.com/en-us/download/dotnet/3.1/runtime?cid=getdotnetcore">.NET 3.1 Runtime</a>のインストールが必要。</p>
-<p><a href="https://dotnet.microsoft.com/en-us/download/dotnet/3.1/runtime?cid=getdotnetcore">Downloadページ</a>から、「Run desktop apps」の「<a href="https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-3.1.25-windows-x86-installer">Download x64</a>」もしくは「<a href="https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-3.1.25-windows-x64-installer">Download x86</a>（32bit OS）」をダウンロードしインストール。</p>
+<p><a href="https://dotnet.microsoft.com/en-us/download/dotnet/6.0/runtime?cid=getdotnetcore">.NET 6 Runtime</a>のインストールが必要。</p>
+<p><a href="https://dotnet.microsoft.com/en-us/download/dotnet/6.0/runtime?cid=getdotnetcore">Downloadページ</a>から、「Run desktop apps」の「<a href="https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-6.0.13-windows-x64-installer">Download x64</a>」もしくは「<a href="https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-6.0.13-windows-x86-installer">Download x86</a>（32bit OS）」をダウンロードしインストール。</p>
 <h2 id="section-2">使い方</h2>
 <h3 id="section-3">クリック間隔設定</h3>
 <p>テキストボックスにミリ秒単位で入力</p>

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 Windows 10(32/64bit), 11(32/64bit)
 
 ## 追加のライブラリ
-[.NET 3.1 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/3.1/runtime?cid=getdotnetcore)のインストールが必要。
+[.NET 6 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0/runtime?cid=getdotnetcore)のインストールが必要。
 
-[Downloadページ](https://dotnet.microsoft.com/en-us/download/dotnet/3.1/runtime?cid=getdotnetcore)から、「Run desktop apps」の「[Download x64](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-3.1.25-windows-x86-installer)」もしくは「[Download x86](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-3.1.25-windows-x64-installer)（32bit OS）」をダウンロードしインストール。
+[Downloadページ](https://dotnet.microsoft.com/en-us/download/dotnet/6.0/runtime?cid=getdotnetcore)から、「Run desktop apps」の「[Download x64](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-6.0.13-windows-x64-installer)」もしくは「[Download x86](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-6.0.13-windows-x86-installer)（32bit OS）」をダウンロードしインストール。
 
 ## 使い方
 ### クリック間隔設定

--- a/SokudaKun.csproj
+++ b/SokudaKun.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>click.ico</ApplicationIcon>
     <Authors>Masakazu Tobeta</Authors>


### PR DESCRIPTION
.NET Core 3.1 のサポートは 2022 年 12 月 13 日に終了しているため、.NET ランタイムを現行の LTS である .NET 6 に更新します。